### PR TITLE
add SlaveOk support at the connection level

### DIFF
--- a/src/robomongo/core/engine/ScriptEngine.cpp
+++ b/src/robomongo/core/engine/ScriptEngine.cpp
@@ -119,6 +119,12 @@ namespace Robomongo
         QTextStream in(&file);
         QString esprima = in.readAll();
 
+        // Enable reads from secondary node
+        if(_connection->slaveOk())
+        {
+            _scope->exec("rs.slaveOk()", "(slaveOk)", false, true, true);
+        }
+
         // Inject Esprima into Javascript scope
         _scope->exec(QtUtils::toStdString(esprima), "(esprima)", true, true, true);
 

--- a/src/robomongo/core/mongodb/MongoClient.cpp
+++ b/src/robomongo/core/mongodb/MongoClient.cpp
@@ -42,9 +42,9 @@ namespace Robomongo
         std::list<std::string> collections;
 
         std::string ns = dbname + ".system.namespaces";
-        std::auto_ptr<mongo::DBClientCursor> c(_dbclient->query( ns.c_str() , mongo::BSONObj(), 0, 0, 0, mongo::QueryOption_SlaveOk, 0 ));
-        while ( c->more() ) {
-            std::string name = c->next()["name"].valuestr();
+        std::auto_ptr<mongo::DBClientCursor> cursor(_dbclient->query( ns.c_str() , mongo::BSONObj(), 0, 0, 0, mongo::QueryOption_SlaveOk, 0 ));
+        while ( cursor->more() ) {
+            std::string name = cursor->next()["name"].valuestr();
             if ( name.find( "$" ) != std::string::npos )
                 continue;
             collections.push_back( name );
@@ -87,7 +87,7 @@ namespace Robomongo
         MongoNamespace ns(dbName, "system.users");
         std::vector<MongoUser> users;
 
-        std::auto_ptr<mongo::DBClientCursor> cursor(_dbclient->query(ns.toString(), mongo::Query()));
+        std::auto_ptr<mongo::DBClientCursor> cursor(_dbclient->query(ns.toString(), mongo::Query(), 0, 0, 0, mongo::QueryOption_SlaveOk, 0));
         float ver = getVersion();
         while (cursor->more()) {
             mongo::BSONObj bsonObj = cursor->next();

--- a/src/robomongo/core/mongodb/MongoClient.cpp
+++ b/src/robomongo/core/mongodb/MongoClient.cpp
@@ -151,7 +151,10 @@ namespace Robomongo
     std::vector<EnsureIndexInfo> MongoClient::getIndexes(const MongoCollectionInfo &collection) const
     {
         std::vector<EnsureIndexInfo> result;
-        std::auto_ptr<mongo::DBClientCursor> cursor(_dbclient->getIndexes(collection.ns().toString()));
+        std::string indexNamespace = mongo::Namespace(collection.ns().toString()).getSisterNS("system.indexes");
+        std::auto_ptr<mongo::DBClientCursor> cursor(_dbclient->
+            query( indexNamespace.c_str(), BSON("ns" << collection.ns().toString()), 0, 0, 0, mongo::QueryOption_SlaveOk, 0)
+        );
 
         while (cursor->more()) {
             mongo::BSONObj bsonObj = cursor->next();

--- a/src/robomongo/core/mongodb/MongoClient.cpp
+++ b/src/robomongo/core/mongodb/MongoClient.cpp
@@ -64,7 +64,7 @@ namespace Robomongo
     {
         float result = 0.0f;
         mongo::BSONObj resultObj;
-        _dbclient->runCommand("db", BSON("buildInfo" << "1"), resultObj, mongo::QueryOption_SlaveOk);
+        _dbclient->runCommand("db", BSON("buildInfo" << "1"), resultObj);
         std::string resultStr = BsonUtils::getField<mongo::String>(resultObj,"version");
         result = atof(resultStr.c_str());
         return result;

--- a/src/robomongo/core/mongodb/MongoClient.cpp
+++ b/src/robomongo/core/mongodb/MongoClient.cpp
@@ -133,7 +133,7 @@ namespace Robomongo
         MongoNamespace ns(dbName, "system.js");
         std::vector<MongoFunction> functions;
 
-        std::auto_ptr<mongo::DBClientCursor> cursor(_dbclient->query(ns.toString(), mongo::Query()));
+        std::auto_ptr<mongo::DBClientCursor> cursor(_dbclient->query(ns.toString(), mongo::Query(), 0, 0, 0, mongo::QueryOption_SlaveOk, 0));
 
         while (cursor->more()) {
             mongo::BSONObj bsonObj = cursor->next();

--- a/src/robomongo/core/mongodb/MongoClient.h
+++ b/src/robomongo/core/mongodb/MongoClient.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mongo/client/dbclientinterface.h>
+#include <mongo/db/namespace-inl.h>
 #include "robomongo/core/Core.h"
 #include "robomongo/core/domain/MongoQueryInfo.h"
 #include "robomongo/core/domain/MongoUser.h"

--- a/src/robomongo/core/settings/ConnectionSettings.cpp
+++ b/src/robomongo/core/settings/ConnectionSettings.cpp
@@ -49,6 +49,7 @@ namespace Robomongo
         inf._currentMethod = static_cast<SSHInfo::SupportedAuthenticationMetods>(map.value("sshAuthMethod").toInt());
         setSshInfo(inf);
 #endif
+       _slaveOk = map.value("slaveOk").toBool();
         QVariantList list = map.value("credentials").toList();
         for(QVariantList::const_iterator it = list.begin(); it != list.end(); ++it) {
             QVariant var = *it;
@@ -81,6 +82,7 @@ namespace Robomongo
     void ConnectionSettings::apply(const ConnectionSettings *source)
     {
         setConnectionName(source->connectionName());
+        setSlaveOk(source->slaveOk());
         setServerHost(source->serverHost());
         setServerPort(source->serverPort());
         setDefaultDatabase(source->defaultDatabase());
@@ -104,6 +106,7 @@ namespace Robomongo
         map.insert("connectionName", QtUtils::toQString(connectionName()));
         map.insert("serverHost", QtUtils::toQString(serverHost()));
         map.insert("serverPort", serverPort());
+        map.insert("slaveOk", slaveOk());
         map.insert("defaultDatabase", QtUtils::toQString(defaultDatabase()));
 #ifdef MONGO_SSL
         SSLInfo infl = _info.sslInfo();

--- a/src/robomongo/core/settings/ConnectionSettings.h
+++ b/src/robomongo/core/settings/ConnectionSettings.h
@@ -56,6 +56,12 @@ namespace Robomongo
         void setServerHost(const std::string &serverHost) { _info.setHost(serverHost); }
 
         /**
+         * @brief SlaveOk
+         */
+        bool slaveOk() const { return _slaveOk; }
+        void setSlaveOk(const bool slaveOk) { _slaveOk = slaveOk; }
+
+        /**
          * @brief Port of server
          */
         unsigned short serverPort() const { return _info.port(); }
@@ -136,6 +142,7 @@ namespace Robomongo
         std::string _connectionName;
         mongo::HostAndPort _info;
         std::string _defaultDatabase;
+        bool _slaveOk;
         QList<CredentialSettings *> _credentials;
     };
 }

--- a/src/robomongo/gui/dialogs/ConnectionBasicTab.cpp
+++ b/src/robomongo/gui/dialogs/ConnectionBasicTab.cpp
@@ -10,7 +10,6 @@
 
 #include "robomongo/core/utils/QtUtils.h"
 #include "robomongo/core/settings/ConnectionSettings.h"
-
 namespace Robomongo
 {
     ConnectionBasicTab::ConnectionBasicTab(ConnectionSettings *settings) :
@@ -29,6 +28,10 @@ namespace Robomongo
         _connectionName = new QLineEdit(QtUtils::toQString(_settings->connectionName()));
         _serverAddress = new QLineEdit(QtUtils::toQString(_settings->serverHost()));
         _serverPort = new QLineEdit(QString::number(_settings->serverPort()));
+
+        _slaveOk = new QCheckBox("Slave OK?");
+        _slaveOk->setChecked(_settings->slaveOk());
+
         _serverPort->setFixedWidth(80);
         QRegExp rx("\\d+");//(0-65554)
         _serverPort->setValidator(new QRegExpValidator(rx, this));
@@ -43,6 +46,7 @@ namespace Robomongo
         connectionLayout->addWidget(new QLabel(":"),              3, 2);
         connectionLayout->addWidget(_serverPort,                  3, 3);
         connectionLayout->addWidget(serverDescriptionLabel,       4, 1, 1, 3);
+        connectionLayout->addWidget(_slaveOk, 5, 1);
 
         QVBoxLayout *mainLayout = new QVBoxLayout;
         mainLayout->addLayout(connectionLayout);
@@ -56,5 +60,6 @@ namespace Robomongo
         _settings->setConnectionName(QtUtils::toStdString(_connectionName->text()));
         _settings->setServerHost(QtUtils::toStdString(_serverAddress->text()));
         _settings->setServerPort(_serverPort->text().toInt());
+        _settings->setSlaveOk(_slaveOk->isChecked());
     }
 }

--- a/src/robomongo/gui/dialogs/ConnectionBasicTab.h
+++ b/src/robomongo/gui/dialogs/ConnectionBasicTab.h
@@ -23,6 +23,7 @@ namespace Robomongo
         QLineEdit *_connectionName;
         QLineEdit *_serverAddress;
         QLineEdit *_serverPort;
+        QCheckBox *_slaveOk;
         ConnectionSettings *const _settings;
     };
 }


### PR DESCRIPTION
I've implemented reading from slaves. I've made a few assumptions which I'm happy to change if people object.
* Collections, indexes, users and functions are *always* loaded with the slaveOk option
* When creating connections, there is a new slaveOk option
* If the slaveOk option is on for your connection, the shell window will open allowing you to read from secondary nodes.