### PR TITLE
Fix #475 wrong type for field (count) 1 != 16

### DIFF
--- a/src/robomongo/core/domain/MongoCollectionInfo.cpp
+++ b/src/robomongo/core/domain/MongoCollectionInfo.cpp
@@ -1,6 +1,7 @@
 #include "MongoCollectionInfo.h"
 #include "robomongo/core/utils/BsonUtils.h"
 #include <mongo/client/dbclient.h>
+#include <robomongo/core/utils/Logger.h>
 
 namespace Robomongo
 {
@@ -11,7 +12,8 @@ namespace Robomongo
         _sizeBytes = BsonUtils::getField<mongo::NumberDouble>(stats,"size");
         _storageSizeBytes = BsonUtils::getField<mongo::NumberDouble>(stats,"storageSize");
 
-        _count = BsonUtils::getField<mongo::NumberInt>(stats,"count");
+        // NumberLong because of mongodb can have very big collections
+        _count = BsonUtils::getField<mongo::NumberLong>(stats,"count");
     }
 }
 

--- a/src/robomongo/core/domain/MongoCollectionInfo.cpp
+++ b/src/robomongo/core/domain/MongoCollectionInfo.cpp
@@ -1,7 +1,6 @@
 #include "MongoCollectionInfo.h"
 #include "robomongo/core/utils/BsonUtils.h"
 #include <mongo/client/dbclient.h>
-#include <robomongo/core/utils/Logger.h>
 
 namespace Robomongo
 {

--- a/src/robomongo/core/domain/MongoCollectionInfo.h
+++ b/src/robomongo/core/domain/MongoCollectionInfo.h
@@ -27,7 +27,7 @@ namespace Robomongo
          */
         double storageSizeBytes() const { return _storageSizeBytes; }
 
-        int count() const { return _count; }
+        long long count() const { return _count; }
 
     private:
         MongoNamespace _ns;
@@ -46,7 +46,7 @@ namespace Robomongo
          */
         double _storageSizeBytes;
 
-        int _count;
+        long long _count;
     };
 }
 

--- a/src/robomongo/gui/widgets/explorer/ExplorerCollectionTreeItem.cpp
+++ b/src/robomongo/gui/widgets/explorer/ExplorerCollectionTreeItem.cpp
@@ -24,7 +24,7 @@ namespace
     const char *tooltipTemplate =
         "%s "
         "<table>"
-        "<tr><td>Count:</td> <td><b>&nbsp;&nbsp;%d</b></td></tr>"
+        "<tr><td>Count:</td> <td><b>&nbsp;&nbsp;%lld</b></td></tr>"
         "<tr><td>Size:</td><td><b>&nbsp;&nbsp;%s</b></td></tr>"
         "</table>"
         ;


### PR DESCRIPTION
Fixed an issue when list database collections and found a big one with large documents count.
Mongodb returns `NumberLong` instead of `NumberInt` for counts greater than 1 billion. 
MongoCollectionInfo was crashed with message "wrong type for field (count) 1 != 16" when was instantiated.
I've changed `_counts` to `long long` instead of `int`.