### PR TITLE
Allow font specification to work around issue #649

### DIFF
--- a/src/robomongo/core/AppRegistry.h
+++ b/src/robomongo/core/AppRegistry.h
@@ -18,7 +18,7 @@ namespace Robomongo
 
     private:
         AppRegistry();
-        ~AppRegistry();  
+        ~AppRegistry();
 
         const EventBusScopedPtr _bus;
         const SettingsManagerScopedPtr _settingsManager;

--- a/src/robomongo/core/settings/SettingsManager.cpp
+++ b/src/robomongo/core/settings/SettingsManager.cpp
@@ -44,7 +44,9 @@ namespace Robomongo
         _viewMode(Robomongo::Tree),
         _autocompletionMode(AutocompleteAll),
         _batchSize(50),
-        _disableConnectionShortcuts(false)
+        _disableConnectionShortcuts(false),
+        _textFontFamily(""),
+        _textFontPointSize(-1)
     {
         load();
         LOG_MSG("SettingsManager initialized in " + _configPath, mongo::LL_INFO, false);
@@ -136,7 +138,7 @@ namespace Robomongo
 
         _autoExpand = map.contains("autoExpand") ?
             map.value("autoExpand").toBool() : true;
-        
+
         _autoExec = map.contains("autoExec") ?
             map.value("autoExec").toBool() : true;
 
@@ -171,6 +173,10 @@ namespace Robomongo
             _currentStyle = AppStyle::StyleName;
         }
 
+        // Load font information
+        _textFontFamily = map.value("textFontFamily").toString();
+        _textFontPointSize = map.value("textFontPointSize").toInt();
+
         // 5. Load connections
         _connections.clear();
 
@@ -179,22 +185,22 @@ namespace Robomongo
             ConnectionSettings *record = new ConnectionSettings((*it).toMap());
             _connections.push_back(record);
         }
-        
+
         _toolbars = map.value("toolbars").toMap();
         ToolbarSettingsContainerType::const_iterator it = _toolbars.find("connect");
-        if (_toolbars.end() == it) 
+        if (_toolbars.end() == it)
             _toolbars["connect"] = true;
         it = _toolbars.find("open_save");
-        if (_toolbars.end() == it) 
+        if (_toolbars.end() == it)
             _toolbars["open_save"] = true;
         it = _toolbars.find("exec");
-        if (_toolbars.end() == it) 
+        if (_toolbars.end() == it)
             _toolbars["exec"] = true;
         it = _toolbars.find("explorer");
-        if (_toolbars.end() == it) 
+        if (_toolbars.end() == it)
             _toolbars["explorer"] = true;
         it = _toolbars.find("logs");
-        if (_toolbars.end() == it) 
+        if (_toolbars.end() == it)
             _toolbars["logs"] = false;
     }
 
@@ -227,14 +233,18 @@ namespace Robomongo
 
         // 7. Save disableConnectionShortcuts
         map.insert("disableConnectionShortcuts", _disableConnectionShortcuts);
-        
+
         // 8. Save batchSize
         map.insert("batchSize", _batchSize);
 
         // 9. Save style
         map.insert("style", _currentStyle);
 
-        // 10. Save connections
+        // 10. Save font information
+        map.insert("textFontFamily", _textFontFamily);
+        map.insert("textFontPointSize", _textFontPointSize);
+
+        // 11. Save connections
         QVariantList list;
 
         for (ConnectionSettingsContainerType::const_iterator it = _connections.begin(); it!=_connections.end(); ++it) {
@@ -243,9 +253,9 @@ namespace Robomongo
         }
 
         map.insert("connections", list);
-        
+
         map.insert("autoExec", _autoExec);
-        
+
         map.insert("toolbars", _toolbars);
 
         return map;
@@ -276,11 +286,20 @@ namespace Robomongo
         _currentStyle = style;
     }
 
+    void SettingsManager::setTextFontFamily(const QString& fontFamily)
+    {
+        _textFontFamily = fontFamily;
+    }
+
+    void SettingsManager::setTextFontPointSize(int pointSize) {
+        _textFontPointSize = pointSize > 0 ? pointSize : -1;
+    }
+
     void SettingsManager::reorderConnections(const ConnectionSettingsContainerType &connections)
     {
         _connections = connections;
     }
-    
+
     void SettingsManager::setToolbarSettings(const QString toolbarName, const bool visible)
     {
         _toolbars[toolbarName] = visible;

--- a/src/robomongo/core/settings/SettingsManager.h
+++ b/src/robomongo/core/settings/SettingsManager.h
@@ -51,7 +51,7 @@ namespace Robomongo
          * Connection now will be owned by SettingsManager.
          */
         void addConnection(ConnectionSettings *connection);
-        
+
         /**
          * @brief Removes connection by index
          */
@@ -60,12 +60,12 @@ namespace Robomongo
         void reorderConnections(const ConnectionSettingsContainerType &connections);
 
         void setToolbarSettings(QString toolbarName, bool visible);
-        
+
         /**
          * @brief Returns list of connections
          */
         ConnectionSettingsContainerType connections() const { return _connections; }
-        
+
         ToolbarSettingsContainerType toolbars() const { return _toolbars; }
 
         void setUuidEncoding(UUIDEncoding encoding) { _uuidEncoding = encoding; }
@@ -82,7 +82,7 @@ namespace Robomongo
 
         void setAutoExpand(bool isExpand) { _autoExpand = isExpand; }
         bool autoExpand() const { return _autoExpand; }
-        
+
         void setAutoExec(bool isAutoExec) { _autoExec = isAutoExec; }
         bool autoExec() const { return _autoExec; }
 
@@ -100,6 +100,12 @@ namespace Robomongo
 
         QString currentStyle() const {return _currentStyle; }
         void setCurrentStyle(const QString& style);
+
+        QString textFontFamily() const { return _textFontFamily; }
+        void setTextFontFamily(const QString& fontFamily);
+
+        int textFontPointSize() const { return _textFontPointSize; }
+        void setTextFontPointSize(int pointSize);
 
 
     private:
@@ -136,6 +142,8 @@ namespace Robomongo
         bool _disableConnectionShortcuts;
         int _batchSize;
         QString _currentStyle;
+        QString _textFontFamily;
+        int _textFontPointSize;
         /**
          * @brief List of connections
          */

--- a/src/robomongo/gui/GuiRegistry.cpp
+++ b/src/robomongo/gui/GuiRegistry.cpp
@@ -1,4 +1,6 @@
 #include "robomongo/gui/GuiRegistry.h"
+#include "robomongo/core/AppRegistry.h"
+#include "robomongo/core/settings/SettingsManager.h"
 
 #include <QApplication>
 #include <QStyle>
@@ -292,15 +294,34 @@ namespace Robomongo
 
     const QFont &GuiRegistry::font() const
     {
-        
+        QString family = AppRegistry::instance().settingsManager()->textFontFamily();
+        if (family.isEmpty()) {
 #if defined(Q_OS_MAC)
-        static const QFont textFont = QFont("Monaco",12);
+            family = "Monaco";
 #elif defined(Q_OS_UNIX)
-        static QFont textFont = QFont("Monospace");
-        textFont.setFixedPitch(true);        
+            family = "Monospace";
 #elif defined(Q_OS_WIN)
-        static const QFont textFont = QFont("Courier",10);
+            family = "Courier";
 #endif
+        }
+
+        int pointSize = AppRegistry::instance().settingsManager()->textFontPointSize();
+        if (pointSize < 1) {
+#if defined(Q_OS_MAC)
+            pointSize = 12
+#elif defined(Q_OS_UNIX)
+            pointSize = -1;
+#elif defined(Q_OS_WIN)
+            pointSize = 10;
+#endif
+        }
+
+
+        static QFont textFont = QFont(family, pointSize);
+#if defined(Q_OS_UNIX)
+        textFont.setFixedPitch(true);
+#endif
+
         return textFont;
     }
 }


### PR DESCRIPTION
Add text font family and point size to SettingsManager and honor in GuiRegistry. This allows Linux users experiencing issue #649 to use a different font (since the default monospace font appears to be giving Qt5 fits on some systems). It is also the first half of implementing #645