### PR TITLE
Fixed CMAKE_INSTALL_PREFIX now has effect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ ELSE()
 ENDIF()
 
 ##################################DEFAULT VALUES##########################################
-IF(NOT CMAKE_INSTALL_PREFIX})
+IF(NOT CMAKE_INSTALL_PREFIX)
     SET(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install")
 ENDIF()
 


### PR DESCRIPTION
`CMAKE_INSTALL_PREFIX` wasn't really having the effect I was expecting until removing the `}`