### PR TITLE
Option to turn off Tabbar

### DIFF
--- a/src/robomongo/core/domain/App.cpp
+++ b/src/robomongo/core/domain/App.cpp
@@ -5,7 +5,9 @@
 #include "robomongo/core/domain/MongoShell.h"
 #include "robomongo/core/domain/MongoCollection.h"
 #include "robomongo/core/settings/ConnectionSettings.h"
+#include "robomongo/core/settings/SettingsManager.h"
 #include "robomongo/core/EventBus.h"
+#include "robomongo/core/AppRegistry.h"
 #include "robomongo/core/utils/QtUtils.h"
 #include "robomongo/core/utils/StdUtils.h"
 #include "robomongo/core/utils/Logger.h"
@@ -98,6 +100,17 @@ namespace Robomongo
 
     MongoShell *App::openShell(ConnectionSettings *connection, const ScriptInfo &scriptInfo)
     {
+        if (!AppRegistry::instance().settingsManager()->useTabbar()) {
+            for (MongoShellsContainerType::const_iterator it = _shells.begin(); it != _shells.end(); ++it) {
+                MongoShell *shell = *it;
+                MongoServer *server = shell->server();
+                ConnectionSettings *settings = server->connectionRecord();
+                if (QString::fromStdString(shell->query()) == scriptInfo.script()
+                    && shell->title() == scriptInfo.title()
+                    && settings->getFullAddress() == connection->getFullAddress())
+                    return shell;
+            }
+        }
         MongoServer *server = openServer(connection, false);
         MongoShell *shell = new MongoShell(server,scriptInfo);
         _shells.push_back(shell);

--- a/src/robomongo/core/domain/MongoServer.cpp
+++ b/src/robomongo/core/domain/MongoServer.cpp
@@ -25,15 +25,15 @@ namespace Robomongo
         return _isConnected;
     }
 
-    ConnectionSettings *MongoServer::connectionRecord() const 
-    { 
-        return _client->connectionRecord(); 
+    ConnectionSettings *MongoServer::connectionRecord() const
+    {
+        return _client->connectionRecord();
     }
 
     MongoServer::~MongoServer()
-    {        
+    {
         clearDatabases();
-        delete _client;
+        _client->stopAndDelete();
     }
 
     /**
@@ -129,7 +129,7 @@ namespace Robomongo
     {
         const ConnectionInfo &info = event->info();
         _isConnected = !event->isError();
-        if (event->isError()) {            
+        if (event->isError()) {
             AppRegistry::instance().bus()->publish(new ConnectionFailedEvent(this, event->error()));
         } else if (_visible) {
             AppRegistry::instance().bus()->publish(new ConnectionEstablishedEvent(this));
@@ -139,7 +139,7 @@ namespace Robomongo
                 MongoDatabase *db  = new MongoDatabase(this, name);
                 addDatabase(db);
             }
-        }        
+        }
         _version = info._version;
     }
 

--- a/src/robomongo/core/mongodb/MongoWorker.h
+++ b/src/robomongo/core/mongodb/MongoWorker.h
@@ -27,7 +27,9 @@ namespace Robomongo
         ConnectionSettings *connectionRecord() const {return _connection;}
         ~MongoWorker();
         enum{pingTimeMs = 60*1000};
-        
+
+        void stopAndDelete();
+
     protected Q_SLOTS: // handlers:
         void init();
         /**
@@ -145,6 +147,7 @@ namespace Robomongo
         const bool _isLoadMongoRcJs;
         const int _batchSize;
         int _timerId;
+        QAtomicInteger<bool> _isQuiting;
 
         ConnectionSettings *_connection;
     };

--- a/src/robomongo/core/settings/SettingsManager.cpp
+++ b/src/robomongo/core/settings/SettingsManager.cpp
@@ -202,6 +202,12 @@ namespace Robomongo
         it = _toolbars.find("logs");
         if (_toolbars.end() == it)
             _toolbars["logs"] = false;
+
+        if (map.contains("useTabbar")) {
+            _useTabbar = map.value("useTabbar").toBool();
+        } else {
+            _useTabbar = true; // Default
+        }
     }
 
     /**
@@ -258,6 +264,8 @@ namespace Robomongo
 
         map.insert("toolbars", _toolbars);
 
+        map.insert("useTabbar", _useTabbar);
+
         return map;
     }
 
@@ -291,8 +299,14 @@ namespace Robomongo
         _textFontFamily = fontFamily;
     }
 
-    void SettingsManager::setTextFontPointSize(int pointSize) {
+    void SettingsManager::setTextFontPointSize(int pointSize)
+    {
         _textFontPointSize = pointSize > 0 ? pointSize : -1;
+    }
+
+    void SettingsManager::setUseTabbar(bool usesTabbar)
+    {
+        _useTabbar = usesTabbar;
     }
 
     void SettingsManager::reorderConnections(const ConnectionSettingsContainerType &connections)

--- a/src/robomongo/core/settings/SettingsManager.h
+++ b/src/robomongo/core/settings/SettingsManager.h
@@ -107,6 +107,9 @@ namespace Robomongo
         int textFontPointSize() const { return _textFontPointSize; }
         void setTextFontPointSize(int pointSize);
 
+        bool useTabbar() const { return _useTabbar; }
+        void setUseTabbar(bool useTabbar);
+
 
     private:
 
@@ -144,6 +147,7 @@ namespace Robomongo
         QString _currentStyle;
         QString _textFontFamily;
         int _textFontPointSize;
+        bool _useTabbar;
         /**
          * @brief List of connections
          */

--- a/src/robomongo/gui/MainWindow.cpp
+++ b/src/robomongo/gui/MainWindow.cpp
@@ -52,16 +52,22 @@ namespace
         Robomongo::AppRegistry::instance().settingsManager()->setViewMode(mode);
         Robomongo::AppRegistry::instance().settingsManager()->save();
     }
-    
+
     void saveAutoExpand(bool isExpand)
     {
         Robomongo::AppRegistry::instance().settingsManager()->setAutoExpand(isExpand);
         Robomongo::AppRegistry::instance().settingsManager()->save();
     }
-    
+
     void saveAutoExec(bool isAutoExec)
     {
         Robomongo::AppRegistry::instance().settingsManager()->setAutoExec(isAutoExec);
+        Robomongo::AppRegistry::instance().settingsManager()->save();
+    }
+
+    void saveUseTabbar(bool usesTabbar)
+    {
+        Robomongo::AppRegistry::instance().settingsManager()->setUseTabbar(usesTabbar);
         Robomongo::AppRegistry::instance().settingsManager()->save();
     }
 
@@ -156,7 +162,7 @@ namespace Robomongo
         _connectButton->setFocusPolicy(Qt::NoFocus);
         _connectButton->setToolTip(QString("Connect to local or remote MongoDB instance <b>(%1 + N)</b>").arg(controlKey));
         _connectButton->setToolButtonStyle(Qt::ToolButtonIconOnly);
-        
+
     #if !defined(Q_OS_MAC)
         _connectButton->setMenu(_connectionsMenu);
         _connectButton->setPopupMode(QToolButton::MenuButtonPopup);
@@ -266,7 +272,7 @@ namespace Robomongo
         defaultViewModeMenu->addAction(treeModeAction);
         defaultViewModeMenu->addAction(tableModeAction);
         defaultViewModeMenu->addAction(textModeAction);
-        
+
         optionsMenu->addSeparator();
 
         QActionGroup *modeGroup = new QActionGroup(this);
@@ -376,12 +382,18 @@ namespace Robomongo
         disabelConnectionShortcuts->setChecked(AppRegistry::instance().settingsManager()->disableConnectionShortcuts());
         VERIFY(connect(disabelConnectionShortcuts, SIGNAL(triggered()), this, SLOT(setDisableConnectionShortcuts())));
         optionsMenu->addAction(disabelConnectionShortcuts);
-        
+
         QAction *autoExec = new QAction(tr("Automatically execute code in new tab"),this);
         autoExec->setCheckable(true);
         autoExec->setChecked(AppRegistry::instance().settingsManager()->autoExec());
         VERIFY(connect(autoExec, SIGNAL(triggered()), this, SLOT(toggleAutoExec())));
         optionsMenu->addAction(autoExec);
+
+        _useTabbarAction = new QAction(tr("Show Tabbar"),this);
+        _useTabbarAction->setCheckable(true);
+        _useTabbarAction->setChecked(AppRegistry::instance().settingsManager()->useTabbar());
+        VERIFY(connect(_useTabbarAction, SIGNAL(triggered()), this, SLOT(toggleUseTabbar())));
+        optionsMenu->addAction(_useTabbarAction);
 
         QAction *preferencesAction = new QAction("Preferences",this);
         VERIFY(connect(preferencesAction, SIGNAL(triggered()), this, SLOT(openPreferences())));
@@ -516,7 +528,7 @@ namespace Robomongo
              styleAction->setCheckable(true);
              styleAction->setChecked(style == currentStyle);
              styleGroup->addAction(styleAction);
-             styles->addAction(styleAction);             
+             styles->addAction(styleAction);
          }
     }
 
@@ -713,11 +725,21 @@ namespace Robomongo
         QAction *send = qobject_cast<QAction*>(sender());
         saveAutoExpand(send->isChecked());
     }
-    
+
     void MainWindow::toggleAutoExec()
     {
         QAction *send = qobject_cast<QAction*>(sender());
         saveAutoExec(send->isChecked());
+    }
+
+    void MainWindow::toggleUseTabbar()
+    {
+        QAction *send = qobject_cast<QAction*>(sender());
+        bool useTabbar = send->isChecked();
+        if (!useTabbar)
+            _workArea->ui_closeOtherTabsRequested(_workArea->currentIndex());
+
+        saveUseTabbar(useTabbar);
     }
 
     void MainWindow::toggleLineNumbers()
@@ -725,7 +747,7 @@ namespace Robomongo
         QAction *send = qobject_cast<QAction*>(sender());
         saveLineNumbers(send->isChecked());
     }
-    
+
     void MainWindow::executeScript()
     {
         QueryWidget *widget = _workArea->currentQueryWidget();
@@ -767,6 +789,10 @@ namespace Robomongo
         QueryWidget *widget = _workArea->currentQueryWidget();
         if (!widget)
             return;
+
+        if (!_useTabbarAction->isChecked()) {
+            _useTabbarAction->trigger();
+        }
 
         widget->duplicate();
     }
@@ -915,37 +941,37 @@ namespace Robomongo
         QWidget *titleWidget = new QWidget(this);         // this lines simply remove
         explorerDock->setTitleBarWidget(titleWidget);     // title bar widget.
         explorerDock->setVisible(AppRegistry::instance().settingsManager()->toolbars()["explorer"].toBool());
-        
+
         QAction *actionExp = explorerDock->toggleViewAction();
-        // Adjust any parameter you want.  
+        // Adjust any parameter you want.
         actionExp->setText(QString("&Explorer"));
-        actionExp->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_E));  
+        actionExp->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_E));
         actionExp->setStatusTip(QString("Press to show/hide Database Explorer panel."));
         actionExp->setChecked(explorerDock->isVisible());
         VERIFY(connect(actionExp, SIGNAL(triggered(bool)), this, SLOT(onExplorerVisibilityChanged(bool))));
-        // Install action in the menu.  
+        // Install action in the menu.
         _viewMenu->addAction(actionExp);
 
         addDockWidget(Qt::LeftDockWidgetArea, explorerDock);
 
-        LogWidget *log = new LogWidget(this);        
+        LogWidget *log = new LogWidget(this);
         VERIFY(connect(&Logger::instance(), SIGNAL(printed(const QString&, mongo::LogLevel)), log, SLOT(addMessage(const QString&, mongo::LogLevel))));
         _logDock = new QDockWidget(tr("Logs"));
         _logDock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea | Qt::TopDockWidgetArea);
         _logDock->setWidget(log);
         _logDock->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable);
         _logDock->setVisible(AppRegistry::instance().settingsManager()->toolbars()["logs"].toBool());
-        
+
         QAction *action = _logDock->toggleViewAction();
-        // Adjust any parameter you want.  
+        // Adjust any parameter you want.
         action->setText(QString("&Logs"));
-        action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_L));  
+        action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_L));
         //action->setStatusTip(QString("Press to show/hide Logs panel."));  //commented for now because this message hides Logs button in status bar :)
         action->setChecked(_logDock->isVisible());
         VERIFY(connect(action, SIGNAL(triggered(bool)), this, SLOT(onLogsVisibilityChanged(bool))));
         // Install action in the menu.
         _viewMenu->addAction(action);
-        
+
         addDockWidget(Qt::BottomDockWidgetArea, _logDock);
     }
 
@@ -974,32 +1000,32 @@ namespace Robomongo
 
         setCentralWidget(window);
     }
-    
+
     void MainWindow::onConnectToolbarVisibilityChanged(bool isVisible)
     {
         AppRegistry::instance().settingsManager()->setToolbarSettings("connect", isVisible);
         AppRegistry::instance().settingsManager()->save();
     }
-    
+
     void MainWindow::onOpenSaveToolbarVisibilityChanged(bool isVisible)
     {
         AppRegistry::instance().settingsManager()->setToolbarSettings("open_save", isVisible);
         AppRegistry::instance().settingsManager()->save();
     }
-    
+
     void MainWindow::onExecToolbarVisibilityChanged(bool isVisible)
     {
         AppRegistry::instance().settingsManager()->setToolbarSettings("exec", isVisible);
         AppRegistry::instance().settingsManager()->save();
     }
-    
-    void MainWindow::onExplorerVisibilityChanged(bool isVisible) 
+
+    void MainWindow::onExplorerVisibilityChanged(bool isVisible)
     {
         AppRegistry::instance().settingsManager()->setToolbarSettings("explorer", isVisible);
         AppRegistry::instance().settingsManager()->save();
     }
-    
-    void MainWindow::onLogsVisibilityChanged(bool isVisible) 
+
+    void MainWindow::onLogsVisibilityChanged(bool isVisible)
     {
         AppRegistry::instance().settingsManager()->setToolbarSettings("logs", isVisible);
         AppRegistry::instance().settingsManager()->save();

--- a/src/robomongo/gui/MainWindow.h
+++ b/src/robomongo/gui/MainWindow.h
@@ -36,6 +36,7 @@ namespace Robomongo
         void enterCustomMode();
         void toggleAutoExpand();
         void toggleAutoExec();
+        void toggleUseTabbar();
         void toggleLineNumbers();
         void executeScript();
         void stopScript();
@@ -71,13 +72,13 @@ namespace Robomongo
         void setUtcTimeZone();
         void setLocalTimeZone();
         void openPreferences();
-        
+
         void onConnectToolbarVisibilityChanged(bool isVisisble);
         void onOpenSaveToolbarVisibilityChanged(bool isVisisble);
         void onExecToolbarVisibilityChanged(bool isVisisble);
         void onExplorerVisibilityChanged(bool isVisisble);
         void onLogsVisibilityChanged(bool isVisible);
-        
+
     private:
         QDockWidget *_logDock;
 
@@ -96,6 +97,7 @@ namespace Robomongo
         QAction *_executeAction;
         QAction *_stopAction;
         QAction *_orientationAction;
+        QAction *_useTabbarAction;
         QToolBar *_execToolBar;
 
         void updateConnectionsMenu();

--- a/src/robomongo/gui/widgets/explorer/ExplorerWidget.cpp
+++ b/src/robomongo/gui/widgets/explorer/ExplorerWidget.cpp
@@ -5,6 +5,7 @@
 #include <QMovie>
 #include <QKeyEvent>
 
+#include "robomongo/core/settings/SettingsManager.h"
 #include "robomongo/core/AppRegistry.h"
 #include "robomongo/core/domain/App.h"
 #include "robomongo/core/utils/QtUtils.h"
@@ -28,6 +29,7 @@ namespace Robomongo
 
         VERIFY(connect(_treeWidget, SIGNAL(itemExpanded(QTreeWidgetItem *)), this, SLOT(ui_itemExpanded(QTreeWidgetItem *))));
         VERIFY(connect(_treeWidget, SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)), this, SLOT(ui_itemDoubleClicked(QTreeWidgetItem *, int))));
+        VERIFY(connect(_treeWidget, SIGNAL(itemClicked(QTreeWidgetItem *, int)), this, SLOT(ui_itemClicked(QTreeWidgetItem *, int))));
 
         setLayout(vlaout);
 
@@ -35,7 +37,7 @@ namespace Robomongo
         _progressLabel = new QLabel(this);
         _progressLabel->setMovie(movie);
         _progressLabel->hide();
-        movie->start();        
+        movie->start();
     }
 
     void ExplorerWidget::keyPressEvent(QKeyEvent *event)
@@ -115,7 +117,7 @@ namespace Robomongo
             serverItem->expand();
             return;
         }
-       
+
         ExplorerCollectionDirIndexesTreeItem * dirItem = dynamic_cast<ExplorerCollectionDirIndexesTreeItem *>(item);
         if (dirItem) {
             dirItem->expand();
@@ -127,6 +129,16 @@ namespace Robomongo
         ExplorerCollectionTreeItem *collectionItem = dynamic_cast<ExplorerCollectionTreeItem *>(item);
         if (collectionItem) {
             AppRegistry::instance().app()->openShell(collectionItem->collection());
+        }
+    }
+
+    void ExplorerWidget::ui_itemClicked(QTreeWidgetItem *item, int cloumn)
+    {
+        if (!AppRegistry::instance().settingsManager()->useTabbar()) {
+            ExplorerCollectionTreeItem *collectionItem = dynamic_cast<ExplorerCollectionTreeItem *>(item);
+            if (collectionItem) {
+                AppRegistry::instance().app()->openShell(collectionItem->collection());
+            }
         }
     }
 }

--- a/src/robomongo/gui/widgets/explorer/ExplorerWidget.h
+++ b/src/robomongo/gui/widgets/explorer/ExplorerWidget.h
@@ -29,9 +29,10 @@ namespace Robomongo
     private Q_SLOTS:
         void ui_itemExpanded(QTreeWidgetItem *item);
         void ui_itemDoubleClicked(QTreeWidgetItem *item, int column);
+        void ui_itemClicked(QTreeWidgetItem *item, int column);
 
     protected:
-        virtual void keyPressEvent(QKeyEvent *event);   
+        virtual void keyPressEvent(QKeyEvent *event);
 
     private:
         int _progress;

--- a/src/robomongo/gui/widgets/workarea/WorkAreaTabWidget.cpp
+++ b/src/robomongo/gui/widgets/workarea/WorkAreaTabWidget.cpp
@@ -2,6 +2,8 @@
 
 #include <QKeyEvent>
 
+#include "robomongo/core/settings/SettingsManager.h"
+#include "robomongo/core/AppRegistry.h"
 #include "robomongo/core/utils/QtUtils.h"
 #include "robomongo/core/KeyboardManager.h"
 #include "robomongo/core/domain/MongoShell.h"
@@ -27,6 +29,7 @@ namespace Robomongo
         setElideMode(Qt::ElideRight);
         setMovable(true);
         setDocumentMode(true);
+        setTabBarAutoHide(true);
         VERIFY(connect(this, SIGNAL(tabCloseRequested(int)), SLOT(tabBar_tabCloseRequested(int))));
         VERIFY(connect(this, SIGNAL(currentChanged(int)), SLOT(ui_currentChanged(int))));
 
@@ -190,7 +193,7 @@ namespace Robomongo
         if(!send)
             return;
 
-        setTabText(indexOf(send), text);        
+        setTabText(indexOf(send), text);
     }
 
     void WorkAreaTabWidget::tooltipTextChange(const QString &text)
@@ -211,10 +214,14 @@ namespace Robomongo
         QueryWidget *queryWidget = new QueryWidget(event->shell,this);
         VERIFY(connect(queryWidget, SIGNAL(titleChanged(const QString &)), this, SLOT(tabTextChange(const QString &))));
         VERIFY(connect(queryWidget, SIGNAL(toolTipChanged(const QString &)), this, SLOT(tooltipTextChange(const QString &))));
-        
+
         addTab(queryWidget, shellName);
 
         setCurrentIndex(count() - 1);
+        if (!AppRegistry::instance().settingsManager()->useTabbar()) {
+            ui_closeOtherTabsRequested(currentIndex());
+        }
+
 #if !defined(Q_OS_MAC)
         setTabIcon(count() - 1, GuiRegistry::instance().mongodbIcon());
 #endif


### PR DESCRIPTION
This pull request adds a new option `Show tabbar` to the options menu. (Also fixes a crash with `MongoWorker`)

<img width="322" alt="option" src="https://cloud.githubusercontent.com/assets/776450/11401739/4bc4bf80-9394-11e5-8398-dffee56028e4.png">

When the tabbar is disabled, a single left click on a collection displays it's contents in the main window.

This is usefull if Robomongo is just used to browse through a database since double clicking a collection will open the tree view children beneath the collection, making the tree view on the left side more and more cluttered.

<img width="235" alt="tree view" src="https://cloud.githubusercontent.com/assets/776450/11401703/1f5b5882-9394-11e5-8e9a-86704140983f.png">

The `Show tabbar` option is on by default which will result in the same behaviour as traditionally Robomongo has.

___

I made this addition primarily because I found Robomongo a bit unplesant when just browsing though collections. I had to double click collections to display them which would also open their subtree in the tree view, so I had to make an additional click to collapse the subtree again. Then after a while I would get quite a lot of taps on the top because I never closed the tabs because clicking on the items in tree view was just more intuitive for me then searching for the collection in the tabbar.

I know that the tabbar is important, so this PR will leave the tabbar on by default. But this PR adds the option to turn the tabbar off and enable a simpler and more intuitive way to use Robomongo for simple use cases.

___

This PR also fixes a bug in `MongoWorker`. When closing a `MongoShell` (By closing a Tab), some objects where destroyed while the thread would still try to send messages to them, resulting in a crash. There where also some problems associated with the deletion of the `QThread` object, the parent object of the `QThread` was wrongfully set to the `MongoWorker` (should be the other way around if anything) resulting in the deletion of locked mutexes which in some cases also caused a crash.

A crash can be reproduced when connecting to a server and very quickly opening a collection and immediately closing it's tab and quickly repeating with different collections. I used the keyboard shortcut to close the tabs. Localhost will also be too fast, I'm connected to a Amazon server which takes about 1-2 seconds to load a collection.