### PR TITLE
Add system tray icon and implement ability to close to system tray (Windows)

### DIFF
--- a/src/robomongo/core/settings/SettingsManager.cpp
+++ b/src/robomongo/core/settings/SettingsManager.cpp
@@ -151,6 +151,9 @@ namespace Robomongo
         _autoExec = map.contains("autoExec") ?
             map.value("autoExec").toBool() : true;
 
+        _minimizeTray = map.contains("minimizeTray") ?
+            map.value("minimizeTray").toBool() : false;
+
         _lineNumbers = map.contains("lineNumbers") ?
             map.value("lineNumbers").toBool() : false;
 
@@ -282,6 +285,8 @@ namespace Robomongo
         map.insert("connections", list);
 
         map.insert("autoExec", _autoExec);
+
+        map.insert("minimizeTray", _minimizeTray);
 
         map.insert("toolbars", _toolbars);
 

--- a/src/robomongo/core/settings/SettingsManager.h
+++ b/src/robomongo/core/settings/SettingsManager.h
@@ -86,6 +86,9 @@ namespace Robomongo
         void setAutoExec(bool isAutoExec) { _autoExec = isAutoExec; }
         bool autoExec() const { return _autoExec; }
 
+        void setMinimizeTray(bool isMinimizingToTray) { _minimizeTray = isMinimizingToTray; }
+        bool minimizeToTray() const { return _minimizeTray; }
+
         void setLineNumbers(bool showLineNumbers) { _lineNumbers = showLineNumbers; }
         bool lineNumbers() const { return _lineNumbers; }
 
@@ -148,6 +151,7 @@ namespace Robomongo
         bool _loadMongoRcJs;
         bool _autoExpand;
         bool _autoExec;
+        bool _minimizeTray;
         bool _lineNumbers;
         bool _disableConnectionShortcuts;
         int _batchSize;

--- a/src/robomongo/gui/MainWindow.h
+++ b/src/robomongo/gui/MainWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QMainWindow>
+#include <QSystemTrayIcon>
 QT_BEGIN_NAMESPACE
 class QLabel;
 class QToolBar;
@@ -32,12 +33,16 @@ namespace Robomongo
     public Q_SLOTS:
         void manageConnections();
         void toggleOrientation();
+        void toggleMinimize();
+        void updateTrayMinimizeAction();
+        void trayActivated(QSystemTrayIcon::ActivationReason reason);
         void enterTextMode();
         void enterTreeMode();
         void enterTableMode();
         void enterCustomMode();
         void toggleAutoExpand();
         void toggleAutoExec();
+        void toggleMinimizeToTray();
         void toggleLineNumbers();
         void executeScript();
         void stopScript();
@@ -51,6 +56,7 @@ namespace Robomongo
         void save();
         void saveAs();
         void changeStyle(QAction *);
+        void exit();
 
         void setDefaultUuidEncoding();
         void setJavaUuidEncoding();
@@ -99,6 +105,8 @@ namespace Robomongo
 
         App *_app;
 
+        bool _allowExit;
+
         ConnectionMenu *_connectionsMenu;
         QToolButton *_connectButton;
         QMenu *_viewMenu;
@@ -111,6 +119,7 @@ namespace Robomongo
         QAction *_stopAction;
         QAction *_orientationAction;
         QToolBar *_execToolBar;
+        QSystemTrayIcon *_trayIcon;
 
     };
 


### PR DESCRIPTION
This pull request adds a new option to the options menu. It allows you make Robomongo close to the system tray. If you're anything like me you like to reduce clutter when developing, so this would be a really useful feature. The option is off by default.

![](http://image.prntscr.com/image/28042a750471467ea255e0d00094e094.png)

This pull request also adds Robomongo to the system tray with the option to show/minimize and exit. Double-clicking on the icon will show the window when it's minimized to the system tray.

![](https://i.gyazo.com/0f576d0505b1e8dc95e92cc0ee273562.gif)
![](https://i.gyazo.com/26cc37406e814bd4ae2605e75cec399f.gif)


These features are implemented to only work on Windows.

## Testing

I have tested this on Windows 10 and OS X (to make sure there was no interference)

