### PR TITLE
#99: Make Edit window modeless

### DIFF
--- a/src/robomongo/core/Enums.h
+++ b/src/robomongo/core/Enums.h
@@ -24,6 +24,13 @@ namespace Robomongo
         Custom = 3
     };
 
+    enum EditWindowMode
+    {
+        Modal = 0,
+        Modeless = 1,
+        Tabbed = 2
+    };
+
     enum AutocompletionMode
     {
         AutocompleteNone = 0,

--- a/src/robomongo/core/domain/Notifier.cpp
+++ b/src/robomongo/core/domain/Notifier.cpp
@@ -20,6 +20,7 @@
 #include "robomongo/gui/utils/DialogUtils.h"
 #include "robomongo/gui/GuiRegistry.h"
 #include "robomongo/core/EventBus.h"
+#include "robomongo/core/domain/App.h"
 
 namespace Robomongo
 {
@@ -284,14 +285,33 @@ namespace Robomongo
 
         const QString &json = QtUtils::toQString(str);
 
-        DocumentTextEditor editor(_queryInfo._info,
-            json, false, dynamic_cast<QWidget*>(_observer));
+        EditWindowMode editWindowMode = AppRegistry::instance().settingsManager()->editWindowMode();
+        if(editWindowMode != Tabbed) {
+            DocumentTextEditor *editor = new DocumentTextEditor(_queryInfo._info, json);
 
-        editor.setWindowTitle("Edit Document");
-        int result = editor.exec();
+            editor->setWindowTitle("Edit Document");
+            switch(editWindowMode)
+            {
+                case Modal:
+                    {
+                        int result = editor->exec();
 
-        if (result == QDialog::Accepted) {
-            _shell->server()->saveDocuments(editor.bsonObj(), _queryInfo._info._ns);
+                        if (result == QDialog::Accepted) {
+                            _shell->server()->saveDocuments(editor->bsonObj(), _queryInfo._info._ns);
+                        }
+                    }
+                    break;
+                case Modeless:
+                    VERIFY(connect(editor, SIGNAL(accepted()), SLOT(documentTextEditorEditAccepted())));
+                    editor->show();
+                    break;
+            }
+        } else {
+            // Show in a tabbed window
+            openCurrentCollectionShell(
+                "save(\n"
+                + json +
+                ");", false);
         }
     }
 
@@ -325,22 +345,49 @@ namespace Robomongo
         if (!_queryInfo._info.isValid())
             return;
 
-        DocumentTextEditor editor(_queryInfo._info,
-            "{\n    \n}", false, dynamic_cast<QWidget*>(_observer));
+        EditWindowMode editWindowMode = AppRegistry::instance().settingsManager()->editWindowMode();
 
-        editor.setCursorPosition(1, 4);
-        editor.setWindowTitle("Insert Document");
+        if(editWindowMode != Tabbed) {
+            DocumentTextEditor *editor = new DocumentTextEditor(_queryInfo._info, "{\n    \n}");
 
-        int result = editor.exec();
-        if (result != QDialog::Accepted)
-            return;
+            editor->setCursorPosition(1, 4);
+            editor->setWindowTitle("Insert Document");
 
-        DocumentTextEditor::ReturnType obj = editor.bsonObj();
-        for (DocumentTextEditor::ReturnType::const_iterator it = obj.begin(); it != obj.end(); ++it) {
-            _shell->server()->insertDocument(*it, _queryInfo._info._ns);
+            switch(editWindowMode)
+            {
+                case Modal:
+                    {
+                        int result = editor->exec();
+                        if (result != QDialog::Accepted)
+                            return;
+
+                        DocumentTextEditor::ReturnType obj = editor->bsonObj();
+                        for (DocumentTextEditor::ReturnType::const_iterator it = obj.begin(); it != obj.end(); ++it) {
+                            _shell->server()->insertDocument(*it, _queryInfo._info._ns);
+                        }
+
+                        _shell->query(0, _queryInfo);
+                    }
+                    break;
+                case Modeless:
+                    VERIFY(connect(editor, SIGNAL(accepted()), SLOT(documentTextEditorInsertAccepted())));
+                    editor->show();
+                    break;
+            }
+        } else {
+            // Show in a tabbed window
+            openCurrentCollectionShell(
+                "insertMany(\n"
+                "    [\n"
+                "        {\n"
+                "            \"key\" : \"value\"\n"
+                "        }\n"
+                "    ],\n"
+                "    {\n"
+                "        ordered: true\n"
+                "    }\n"
+                ");", false);
         }
-
-        _shell->query(0, _queryInfo);
     }
 
     void Notifier::onCopyDocument()
@@ -422,4 +469,27 @@ namespace Robomongo
          const QString &json = QtUtils::toQString(str);
          clipboard->setText(json);
      }
+
+    void Notifier::documentTextEditorInsertAccepted()
+    {
+        DocumentTextEditor *editor = (DocumentTextEditor*)QObject::sender();
+        DocumentTextEditor::ReturnType obj = editor->bsonObj();
+        for (DocumentTextEditor::ReturnType::const_iterator it = obj.begin(); it != obj.end(); ++it) {
+            _shell->server()->insertDocument(*it, _queryInfo._info._ns);
+        }
+
+        _shell->query(0, _queryInfo);
+    }
+
+    void Notifier::openCurrentCollectionShell(const QString &script, bool execute, const CursorPosition &cursor)
+    {
+        QString query = detail::buildCollectionQuery(_queryInfo._info._ns.collectionName(), script);
+        AppRegistry::instance().app()->openShell(_shell->server(), query, _queryInfo._info._ns.databaseName(), execute, QtUtils::toQString(_queryInfo._info._ns.collectionName()), cursor);
+    }
+
+    void Notifier::documentTextEditorEditAccepted()
+    {
+        DocumentTextEditor *editor = (DocumentTextEditor*)QObject::sender();
+        _shell->server()->saveDocuments(editor->bsonObj(), _queryInfo._info._ns);
+    }
 }

--- a/src/robomongo/core/domain/Notifier.h
+++ b/src/robomongo/core/domain/Notifier.h
@@ -3,6 +3,7 @@
 #include <QModelIndex>
 
 #include "robomongo/core/domain/MongoQueryInfo.h"
+#include "robomongo/core/domain/CursorPosition.h"
 
 QT_BEGIN_NAMESPACE
 class QAction;
@@ -59,6 +60,8 @@ namespace Robomongo
         void onCopyJson();
         void handle(InsertDocumentResponse *event);
         void handle(RemoveDocumentResponse *event);
+        void documentTextEditorInsertAccepted();
+        void documentTextEditorEditAccepted();
 
     private:
         QAction *_deleteDocumentAction;
@@ -73,5 +76,7 @@ namespace Robomongo
 
         MongoShell *_shell;
         INotifierObserver *const _observer;
+
+        void openCurrentCollectionShell(const QString &script, bool execute = true, const CursorPosition &cursor = CursorPosition());
     };
 }

--- a/src/robomongo/core/settings/SettingsManager.cpp
+++ b/src/robomongo/core/settings/SettingsManager.cpp
@@ -46,6 +46,7 @@ namespace Robomongo
         _uuidEncoding(DefaultEncoding),
         _timeZone(Utc),
         _viewMode(Robomongo::Tree),
+        _editWindowMode(Robomongo::Modal),
         _autocompletionMode(AutocompleteAll),
         _batchSize(50),
         _disableConnectionShortcuts(false),
@@ -143,6 +144,14 @@ namespace Robomongo
             _viewMode = (ViewMode) viewMode;
         } else {
             _viewMode = Custom; // Default View Mode
+        }
+
+        // 4. Load edit window mode
+        if (map.contains("editWindowMode")) {
+            int editWindowMode = map.value("editWindowMode").toInt();
+            _editWindowMode = (EditWindowMode) editWindowMode;
+        } else {
+            _editWindowMode = Modal; // Default Edit Window Mode
         }
 
         _autoExpand = map.contains("autoExpand") ?
@@ -250,28 +259,31 @@ namespace Robomongo
         map.insert("autoExpand", _autoExpand);
         map.insert("lineNumbers", _lineNumbers);
 
-        // 5. Save Autocompletion mode
+        // 5 Save edit window mode
+        map.insert("editWindowMode", _editWindowMode);
+
+        // 6. Save Autocompletion mode
         map.insert("autocompletionMode", _autocompletionMode);
 
-        // 6. Save loadInitJs
+        // 7. Save loadInitJs
         map.insert("loadMongoRcJs", _loadMongoRcJs);
 
-        // 7. Save disableConnectionShortcuts
+        // 8. Save disableConnectionShortcuts
         map.insert("disableConnectionShortcuts", _disableConnectionShortcuts);
 
-        // 8. Save batchSize
+        // 9. Save batchSize
         map.insert("batchSize", _batchSize);
         map.insert("mongoTimeoutSec", _mongoTimeoutSec);
         map.insert("shellTimeoutSec", _shellTimeoutSec);
 
-        // 9. Save style
+        // 10. Save style
         map.insert("style", _currentStyle);
 
-        // 10. Save font information
+        // 11. Save font information
         map.insert("textFontFamily", _textFontFamily);
         map.insert("textFontPointSize", _textFontPointSize);
 
-        // 11. Save connections
+        // 12. Save connections
         QVariantList list;
 
         for (ConnectionSettingsContainerType::const_iterator it = _connections.begin(); it != _connections.end(); ++it) {

--- a/src/robomongo/core/settings/SettingsManager.h
+++ b/src/robomongo/core/settings/SettingsManager.h
@@ -77,6 +77,9 @@ namespace Robomongo
         void setViewMode(ViewMode viewMode) { _viewMode = viewMode; }
         ViewMode viewMode() const { return _viewMode; }
 
+        void setEditWindowMode(EditWindowMode editWindowMode) { _editWindowMode = editWindowMode; }
+        EditWindowMode editWindowMode() const { return _editWindowMode; }
+
         void setAutocompletionMode(AutocompletionMode mode) { _autocompletionMode = mode; }
         AutocompletionMode autocompletionMode() const { return _autocompletionMode; }
 
@@ -144,6 +147,7 @@ namespace Robomongo
         UUIDEncoding _uuidEncoding;
         SupportedTimes _timeZone;
         ViewMode _viewMode;
+        EditWindowMode _editWindowMode;
         AutocompletionMode _autocompletionMode;
         bool _loadMongoRcJs;
         bool _autoExpand;

--- a/src/robomongo/gui/MainWindow.cpp
+++ b/src/robomongo/gui/MainWindow.cpp
@@ -55,6 +55,12 @@ namespace
         Robomongo::AppRegistry::instance().settingsManager()->setViewMode(mode);
         Robomongo::AppRegistry::instance().settingsManager()->save();
     }
+
+    void saveEditWindowMode(Robomongo::EditWindowMode mode)
+    {
+        Robomongo::AppRegistry::instance().settingsManager()->setEditWindowMode(mode);
+        Robomongo::AppRegistry::instance().settingsManager()->save();
+    }
     
     void saveAutoExpand(bool isExpand)
     {
@@ -212,6 +218,30 @@ namespace Robomongo
         customModeAction->setChecked(viewMode == Custom);
         VERIFY(connect(customModeAction, SIGNAL(triggered()), this, SLOT(enterCustomMode())));
 
+        // read edit window mode setting
+        EditWindowMode editWindowMode = AppRegistry::instance().settingsManager()->editWindowMode();
+
+        // Modal Window Action
+        QAction *modalWindowAction = new QAction("&Modal Window", this);
+        modalWindowAction->setToolTip("Show document edit in a modal window");
+        modalWindowAction->setCheckable(true);
+        modalWindowAction->setChecked(editWindowMode == Modal);
+        VERIFY(connect(modalWindowAction, SIGNAL(triggered()), this, SLOT(setModalWindowMode())));
+
+        // Modeless Window Action
+        QAction *modelessWindowAction = new QAction("&Modeless Window", this);
+        modelessWindowAction->setToolTip("Show document edit in a modeless window");
+        modelessWindowAction->setCheckable(true);
+        modelessWindowAction->setChecked(editWindowMode == Modeless);
+        VERIFY(connect(modelessWindowAction, SIGNAL(triggered()), this, SLOT(setModelessWindowMode())));
+
+        // Tabbed Window Action
+        QAction *tabbedWindowAction = new QAction("&Tabbed Window", this);
+        tabbedWindowAction->setToolTip("Show document edit in a tabbed window");
+        tabbedWindowAction->setCheckable(true);
+        tabbedWindowAction->setChecked(editWindowMode == Tabbed);
+        VERIFY(connect(tabbedWindowAction, SIGNAL(triggered()), this, SLOT(setTabbedWindowMode())));
+
         // Execute action
         _executeAction = new QAction(this);
         _executeAction->setData("Execute");
@@ -265,14 +295,25 @@ namespace Robomongo
         defaultViewModeMenu->addAction(treeModeAction);
         defaultViewModeMenu->addAction(tableModeAction);
         defaultViewModeMenu->addAction(textModeAction);
-        
-        optionsMenu->addSeparator();
 
         QActionGroup *modeGroup = new QActionGroup(this);
         modeGroup->addAction(textModeAction);
         modeGroup->addAction(treeModeAction);
         modeGroup->addAction(tableModeAction);
         modeGroup->addAction(customModeAction);
+
+        // Edit window mode
+        QMenu *defaultEditWindowModeMenu = optionsMenu->addMenu("Edit Window Mode");
+        defaultEditWindowModeMenu->addAction(modalWindowAction);
+        defaultEditWindowModeMenu->addAction(modelessWindowAction);
+        defaultEditWindowModeMenu->addAction(tabbedWindowAction);
+
+        QActionGroup *editWindowModeGroup = new QActionGroup(this);
+        editWindowModeGroup->addAction(modalWindowAction);
+        editWindowModeGroup->addAction(modelessWindowAction);
+        editWindowModeGroup->addAction(tabbedWindowAction);
+
+        optionsMenu->addSeparator();
 
         // Time Zone
         QAction *utcTime = new QAction(convertTimesToString(Utc), this);
@@ -758,6 +799,21 @@ namespace Robomongo
             return;
 
         widget->enterCustomMode();
+    }
+
+    void MainWindow::setModalWindowMode()
+    {
+        saveEditWindowMode(Modal);
+    }
+
+    void MainWindow::setModelessWindowMode()
+    {
+        saveEditWindowMode(Modeless);
+    }
+
+    void MainWindow::setTabbedWindowMode()
+    {
+        saveEditWindowMode(Tabbed);
     }
 
     void MainWindow::toggleAutoExpand()

--- a/src/robomongo/gui/MainWindow.h
+++ b/src/robomongo/gui/MainWindow.h
@@ -36,6 +36,9 @@ namespace Robomongo
         void enterTreeMode();
         void enterTableMode();
         void enterCustomMode();
+        void setModalWindowMode();
+        void setModelessWindowMode();
+        void setTabbedWindowMode();
         void toggleAutoExpand();
         void toggleAutoExec();
         void toggleLineNumbers();

--- a/src/robomongo/gui/widgets/explorer/ExplorerCollectionTreeItem.h
+++ b/src/robomongo/gui/widgets/explorer/ExplorerCollectionTreeItem.h
@@ -52,6 +52,7 @@ namespace Robomongo
         void ui_duplicateCollection();
         void ui_copyToCollectionToDiffrentServer();
         void ui_viewCollection();
+        void documentTextEditorAccepted();
 
     private:
         QString buildToolTip(MongoCollection *collection);

--- a/src/robomongo/gui/widgets/explorer/ExplorerDatabaseCategoryTreeItem.h
+++ b/src/robomongo/gui/widgets/explorer/ExplorerDatabaseCategoryTreeItem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "robomongo/gui/widgets/explorer/ExplorerTreeItem.h"
+#include "robomongo/core/domain/CursorPosition.h"
 
 namespace Robomongo
 {
@@ -39,5 +40,6 @@ namespace Robomongo
     private:
         ExplorerDatabaseTreeItem *databaseItem() const;
         const ExplorerDatabaseCategory _category;
+        void openCurrentCollectionShell(const QString &script, bool execute = true, const CursorPosition &cursor = CursorPosition());
     };
 }

--- a/src/robomongo/gui/widgets/explorer/ExplorerFunctionTreeItem.cpp
+++ b/src/robomongo/gui/widgets/explorer/ExplorerFunctionTreeItem.cpp
@@ -9,8 +9,11 @@
 
 #include "robomongo/core/domain/MongoDatabase.h"
 #include "robomongo/core/domain/MongoServer.h"
+#include "robomongo/core/domain/App.h"
 #include "robomongo/core/settings/ConnectionSettings.h"
+#include "robomongo/core/settings/SettingsManager.h"
 #include "robomongo/core/utils/QtUtils.h"
+#include "robomongo/core/AppRegistry.h"
 
 namespace Robomongo
 {
@@ -45,19 +48,38 @@ namespace Robomongo
     {
         std::string name = _function.name();
 
-        FunctionTextEditor dlg(QtUtils::toQString(_database->server()->connectionRecord()->getFullAddress()),
-            QtUtils::toQString(_database->name()),
-            _function);
-        dlg.setWindowTitle("Edit Function");
-        int result = dlg.exec();
+        EditWindowMode editWindowMode = AppRegistry::instance().settingsManager()->editWindowMode();
+        if(editWindowMode != Tabbed) {
+            FunctionTextEditor *dlg = new FunctionTextEditor(QtUtils::toQString(_database->server()->connectionRecord()->getFullAddress()),
+                QtUtils::toQString(_database->name()),
+                _function);
+            dlg->setWindowTitle("Edit Function");
+            switch(editWindowMode)
+            {
+                case Modal:
+                    {
+                        int result = dlg->exec();
 
-        if (result == QDialog::Accepted) {
+                        if (result == QDialog::Accepted) {
 
-            MongoFunction editedFunction = dlg.function();
-            _database->updateFunction(name, editedFunction);
+                            MongoFunction editedFunction = dlg->function();
+                            _database->updateFunction(name, editedFunction);
 
-            // refresh list of functions
-            _database->loadFunctions();
+                            // refresh list of functions
+                            _database->loadFunctions();
+                        }
+                    }
+                    break;
+                case Modeless:
+                    VERIFY(connect(dlg, SIGNAL(accepted()), SLOT(functionTextEditorEditAccepted())));
+                    dlg->show();
+                    break;
+            }
+        } else {
+            openCurrentCollectionShell(QtUtils::toQString("{\n"
+                "    _id: \""+name+"\",\n"
+                "    value : " + _function.code() + ""
+                "}"), false);
         }
     }
 
@@ -71,5 +93,21 @@ namespace Robomongo
 
         _database->dropFunction(_function.name());
         _database->loadFunctions(); // refresh list of functions
+    }
+
+    void ExplorerFunctionTreeItem::functionTextEditorEditAccepted()
+    {
+        FunctionTextEditor *dlg = (FunctionTextEditor*)QObject::sender();
+        MongoFunction editedFunction = dlg->function();
+        _database->updateFunction(_function.name(), editedFunction);
+
+        // refresh list of functions
+        _database->loadFunctions();
+    }
+
+    void ExplorerFunctionTreeItem::openCurrentCollectionShell(const QString &script, bool execute, const CursorPosition &cursor)
+    {
+        QString query = "db.system.js.save(" + script + ")";
+        AppRegistry::instance().app()->openShell(_database, query, execute, "Edit Function", cursor);
     }
 }

--- a/src/robomongo/gui/widgets/explorer/ExplorerFunctionTreeItem.h
+++ b/src/robomongo/gui/widgets/explorer/ExplorerFunctionTreeItem.h
@@ -2,6 +2,7 @@
 
 #include "robomongo/core/domain/MongoFunction.h"
 #include "robomongo/gui/widgets/explorer/ExplorerTreeItem.h"
+#include "robomongo/core/domain/CursorPosition.h"
 
 namespace Robomongo
 {
@@ -24,6 +25,7 @@ namespace Robomongo
         QString buildToolTip(const MongoFunction &function);
         MongoFunction _function;
         MongoDatabase *_database;
+        void openCurrentCollectionShell(const QString &script, bool execute = true, const CursorPosition &cursor = CursorPosition());
     };
 }
 


### PR DESCRIPTION
This commit adds a new action group under the "Options" menu item that
changes the mode to present the insert/edit document/function edit
window.
The options are:
- Modal: the edit window is show in a modal dialog, this is the default
mode
- Modeless: the edit dialog will be modeless.
- Tabbed: the edit will be made with a mongo shell script  in a new tab

The edit was tested on a Windows 10 x64 machine
See https://github.com/paralect/robomongo/issues/99