### PR TITLE
Move Gitter badge to the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 About Robomongo
 ===============
 
+[![Join the chat at https://gitter.im/paralect/robomongo](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/paralect/robomongo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 [Robomongo](http://www.robomongo.org) is a shell-centric cross-platform MongoDB management tool. Unlike most other MongoDB admin UI tools, Robomongo embeds the actual `mongo` shell in a tabbed interface with access to a shell command line as well as GUI interaction.
 
 Starting from version 0.9, Robomongo is compatibile with MongoDB 3.x (including SCRAM-SHA-1 auth and support for WiredTiger storage engine). Robomongo 0.9 embeds the **MongoDB 3.2** shell.
@@ -89,7 +91,7 @@ You can:
 
  - [Create a new issue in the Github issue queue](https://github.com/paralect/robomongo/issues)
 
- - [Join developer discussion on Gitter](https://gitter.im/paralect/robomongo) [![Join the chat at https://gitter.im/paralect/robomongo](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/paralect/robomongo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+ - [Join developer discussion on Gitter](https://gitter.im/paralect/robomongo)
 
 Build
 =====


### PR DESCRIPTION
This is quite a preferred position for most projects and it helps to be this visible. I personally thought Robomongo is not using Gitter at first.
